### PR TITLE
Automatically select the search bar upon page load

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         </div>
         <div class="header-item header-search">
           <form class="search" action="" method="get" name="search">
-            <input name="searchbar" class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="true">
+            <input name="searchbar" class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1">
             <input type="submit" value="Search" class="is-hidden">
           </form>
           <button class="button mb-0 ml-3 search-clear" tabindex="1" disabled>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         </div>
         <div class="header-item header-search">
           <form class="search" action="" method="get">
-            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="true">
+            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="autofocus">
             <input type="submit" value="Search" class="is-hidden">
           </form>
           <button class="button mb-0 ml-3 search-clear" tabindex="1" disabled>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         </div>
         <div class="header-item header-search">
           <form class="search" action="" method="get">
-            <input class="search-input mb-0" type="text" placeholder="Find or Search" tabindex="1" name="q" autocomplete="off" tabindex="1">
+            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus>
             <input type="submit" value="Search" class="is-hidden">
           </form>
           <button class="button mb-0 ml-3 search-clear" tabindex="1" disabled>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         </div>
         <div class="header-item header-search">
           <form class="search" action="" method="get">
-            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="autofocus">
+            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="true">
             <input type="submit" value="Search" class="is-hidden">
           </form>
           <button class="button mb-0 ml-3 search-clear" tabindex="1" disabled>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <link rel="stylesheet" href="css/link.css">
 </head>
 
-<body>
+<body OnLoad="document.search.searchbar.focus();">
 
 
   <header class="header">
@@ -41,8 +41,8 @@
           <p class="date"></p>
         </div>
         <div class="header-item header-search">
-          <form class="search" action="" method="get">
-            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="true">
+          <form class="search" action="" method="get" name="search">
+            <input name="searchbar" class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="true">
             <input type="submit" value="Search" class="is-hidden">
           </form>
           <button class="button mb-0 ml-3 search-clear" tabindex="1" disabled>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         </div>
         <div class="header-item header-search">
           <form class="search" action="" method="get">
-            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus>
+            <input class="search-input mb-0" type="text" placeholder="Find Bookmarks or Search" tabindex="1" name="q" autocomplete="off" tabindex="1" autofocus="true">
             <input type="submit" value="Search" class="is-hidden">
           </form>
           <button class="button mb-0 ml-3 search-clear" tabindex="1" disabled>


### PR DESCRIPTION
I found that not having the search bar auto-focus impeded on my ability to quickly open a tab and start typing for a search. This fixes that issue by automatically selecting the search bar upon page load.