### PR TITLE
[bug] generate and link complete sourcemap

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,14 +97,18 @@ const build = {
       .pipe(dest(path.build + '/css'))
   },
   jsDependencies: function() {
-    return src(jsDependencies, { sourcemaps: true })
+    return src(jsDependencies, {
+        sourcemaps: true
+      })
       .pipe(concat(filename.jsDependencies))
       .pipe(dest(path.build + '/js', {
-        sourcemaps:true
+        sourcemaps: true
       }))
   },
   jsFiles: function() {
-    return src(jsFiles, { sourcemaps: true })
+    return src(jsFiles, {
+        sourcemaps: true
+      })
       .pipe(concat(filename.jsFiles))
       .pipe(uglify())
       .pipe(dest(path.build + '/js', {
@@ -112,14 +116,22 @@ const build = {
       }))
   },
   js: function() {
-    return src([path.build + '/js/' + filename.jsDependencies, path.build + '/js/' + filename.jsFiles], { sourcemaps: true })
+    return src([
+        path.build + '/js/' + filename.jsDependencies,
+        path.build + '/js/' + filename.jsFiles
+      ], {
+        sourcemaps: true
+      })
       .pipe(concat(filename.js))
       .pipe(dest(path.build + '/js', {
         sourcemaps: '.'
       }))
   },
   jsClean: function() {
-    return src([path.build + '/js/' + filename.jsDependencies, path.build + '/js/' + filename.jsFiles])
+    return src([
+        path.build + '/js/' + filename.jsDependencies,
+        path.build + '/js/' + filename.jsFiles
+      ])
       .pipe(clean())
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,20 +97,22 @@ const build = {
       .pipe(dest(path.build + '/css'))
   },
   jsDependencies: function() {
-    return src(jsDependencies)
+    return src(jsDependencies, { sourcemaps: true })
       .pipe(concat(filename.jsDependencies))
-      .pipe(dest(path.build + '/js'))
+      .pipe(dest(path.build + '/js', {
+        sourcemaps:true
+      }))
   },
   jsFiles: function() {
-    return src(jsFiles)
+    return src(jsFiles, { sourcemaps: true })
       .pipe(concat(filename.jsFiles))
       .pipe(uglify())
       .pipe(dest(path.build + '/js', {
-        sourcemaps: '.'
+        sourcemaps: true
       }))
   },
   js: function() {
-    return src([path.build + '/js/' + filename.jsDependencies, path.build + '/js/' + filename.jsFiles])
+    return src([path.build + '/js/' + filename.jsDependencies, path.build + '/js/' + filename.jsFiles], { sourcemaps: true })
       .pipe(concat(filename.js))
       .pipe(dest(path.build + '/js', {
         sourcemaps: '.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nighttab",
-  "version": "3.75.0",
+  "version": "3.75.1",
   "description": "A neutral new tab page accented with a chosen colour. Customise the layout, style, background and bookmarks in nightTab.",
   "main": "index.js",
   "scripts": {

--- a/src/js/version.js
+++ b/src/js/version.js
@@ -1,6 +1,6 @@
 var version = (function() {
 
-  var current = "3.75.0";
+  var current = "3.75.1";
 
   var compare = function(a, b) {
     var pa = a.split(".");

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "nightTab",
   "short_name": "nightTab",
   "description": "A neutral new tab page accented with a chosen colour. Customise the layout, style, background and bookmarks in nightTab.",
-  "version": "3.75.0",
+  "version": "3.75.1",
   "manifest_version": 2,
   "chrome_url_overrides": {
     "newtab": "index.html"


### PR DESCRIPTION
Hello @zombieFox 
As you can see here

https://github.com/zombieFox/nightTab/blob/ba4e420e67f0e4311800304cd10138e7e2c734af/js/nighttab.min.js#L2

in v3.75.0, the final minimized file link to a source file that does not exist, which creates an annoying warning message in the browser dev console. (https://developer.mozilla.org/en-US/docs/Tools/Debugger/Source_map_errors)

In this PR I'm assuming that you're OK with distributing the sourcemaps (I hope so) but, in case you're not, stripping away the linked line seems the way to go.

This fix generate `nighttab.min.js.map` that contains info about both the vendors (in typescript format) and your scripts.

Tested in Firefox 68.0.2