### PR TITLE
Spelling updates

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -607,7 +607,7 @@
                 </div>
                 <div class="input-wrap">
                   <input id="control-header-search-engine-duckduckgo" class="control-header-search-engine-duckduckgo" type="radio" name="control-header-search-engine" value="duckduckgo" tabindex="-1">
-                  <label for="control-header-search-engine-duckduckgo">Duck Duck Go</label>
+                  <label for="control-header-search-engine-duckduckgo">DuckDuckGo</label>
                 </div>
                 <div class="input-wrap">
                   <input id="control-header-search-engine-youtube" class="control-header-search-engine-youtube" type="radio" name="control-header-search-engine" value="youtube" tabindex="-1">
@@ -1132,7 +1132,7 @@
                   <hr>
                   <p class="control-background-image-url-helper form-helper small">Unsplash can be used for random images, eg:</p>
                   <p class="control-background-image-url-helper form-helper small"><i>https://source.unsplash.com/random/1920x1080/?night,day,sky</i></p>
-                  <p class="control-background-image-url-helper form-helper small">Change parameters after <i>.../ramdom/</i> for more options. Loading times may vary.</p>
+                  <p class="control-background-image-url-helper form-helper small">Change parameters after <i>.../random/</i> for more options. Loading times may vary.</p>
                 </div>
                 <hr>
                 <div class="input-wrap">


### PR DESCRIPTION
- `random` was misspelled `ramdom` in URL example, which could cause broken links
- `Duck Duck Go` is spelled without spaces