### PR TITLE
Add service worker

### DIFF
--- a/src/component/data/index.js
+++ b/src/component/data/index.js
@@ -240,6 +240,26 @@ data.remove = (key) => {
   window.localStorage.removeItem(key);
 };
 
+data.clear_serviceWorker = () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then((registrations) => {
+      registrations.forEach((registration) => {
+        registration.unregister();
+      });
+    });
+  }
+};
+
+data.clear_cache = () => {
+  if ('caches' in window) {
+    caches.keys().then((cacheNames) => {
+      cacheNames.forEach((cacheName) => {
+        caches.delete(cacheName);
+      });
+    });
+  }
+};
+
 data.backup = (dataToBackup) => {
   if (dataToBackup) {
     data.set(APP_NAME + 'Backup', JSON.stringify(dataToBackup));
@@ -315,11 +335,16 @@ data.load = () => {
 
 data.wipe = {
   all: () => {
+    data.clear_serviceWorker();
+    data.clear_cache();
+  
     data.remove(APP_NAME);
 
     data.reload.render();
   },
   partial: () => {
+    data.clear_serviceWorker();
+    data.clear_cache();
     bookmark.reset();
 
     data.set(APP_NAME, JSON.stringify({

--- a/src/component/version/index.js
+++ b/src/component/version/index.js
@@ -1,38 +1,36 @@
-export const version = {};
+export const version = {
+  number: '7.5.0',
+  name: 'Delightful Komodo Dragon',
+  compare: (a, b) => {
 
-version.number = '7.5.0';
+    let pa = a.split('.');
 
-version.name = 'Delightful Komodo Dragon';
+    let pb = b.split('.');
 
-version.compare = (a, b) => {
+    for (let i = 0; i < 3; i++) {
 
-  let pa = a.split('.');
+      let na = Number(pa[i]);
 
-  let pb = b.split('.');
+      let nb = Number(pb[i]);
 
-  for (let i = 0; i < 3; i++) {
+      if (na > nb) {
+        return 1;
+      }
 
-    let na = Number(pa[i]);
+      if (nb > na) {
+        return -1;
+      }
 
-    let nb = Number(pb[i]);
+      if (!isNaN(na) && isNaN(nb)) {
+        return 1;
+      }
 
-    if (na > nb) {
-      return 1;
+      if (isNaN(na) && !isNaN(nb)) {
+        return -1;
+      }
+
     }
 
-    if (nb > na) {
-      return -1;
-    }
-
-    if (!isNaN(na) && isNaN(nb)) {
-      return 1;
-    }
-
-    if (isNaN(na) && !isNaN(nb)) {
-      return -1;
-    }
-
+    return 0;
   }
-
-  return 0;
 };

--- a/src/initialBackground.js
+++ b/src/initialBackground.js
@@ -13,3 +13,13 @@ if (localStorage.getItem('nightTabStyle')) {
   }
   document.querySelector('head').appendChild(style);
 }
+
+// check if service worker is available
+if ('serviceWorker' in navigator) {
+  // register service worker
+  navigator.serviceWorker.register('./service_worker.js').then(() => {
+    console.log('serviceWorker registered');
+  }).catch(error => {
+    console.log('serviceWorker registration failed', error);
+  });
+}

--- a/src/serviceWorker/cachingStrategy.js
+++ b/src/serviceWorker/cachingStrategy.js
@@ -11,27 +11,23 @@ export const cacheFirst = async function (cacheName, event) {
   }
   // miss
   else {
-    return fetch(request).then(response => {
-      let responseClone = response.clone();
-      caches.open(cacheName).then(cache =>
-        cache.put(request, responseClone)
-      );
-      return response;
-    });
+    const fetchResponse = await fetch(request);
+    const fetchResponseClone = fetchResponse.clone();
+    const cache = await caches.open(cacheName);
+    await cache.put(request, fetchResponseClone);
+    return fetchResponse;
   }
 };
+
 
 export const networkFirst = async function (cacheName, event) {
   let request = event.request;
   try {
-    return fetch(request).then(
-      response => {
-        let responseClone = response.clone();
-        caches.open(cacheName).then(cache =>
-          cache.put(request, responseClone)
-        );
-        return response;
-      });
+    const fetchResponse = await fetch(request);
+    const fetchResponseClone = fetchResponse.clone();
+    const cache = await caches.open(cacheName);
+    await cache.put(request, fetchResponseClone);
+    return fetchResponse;
   }
   catch (err) {
     return caches.match(event.request);

--- a/src/serviceWorker/cachingStrategy.js
+++ b/src/serviceWorker/cachingStrategy.js
@@ -1,0 +1,69 @@
+// Caching strategies for service workers
+// For more details refer
+// https://web.dev/learn/pwa/caching/
+
+export const cacheFirst = async function (cacheName, event) {
+  let cacheResponse = await caches.match(event.request);
+  let request = event.request;
+  if (cacheResponse !== undefined) {
+    // cache hit
+    return cacheResponse;
+  }
+  // miss
+  else {
+    return fetch(request).then(response => {
+      let responseClone = response.clone();
+      caches.open(cacheName).then(cache =>
+        cache.put(request, responseClone)
+      );
+      return response;
+    });
+  }
+};
+
+export const networkFirst = async function (cacheName, event) {
+  let request = event.request;
+  try {
+    return fetch(request).then(
+      response => {
+        let responseClone = response.clone();
+        caches.open(cacheName).then(cache =>
+          cache.put(request, responseClone)
+        );
+        return response;
+      });
+  }
+  catch (err) {
+    return caches.match(event.request);
+  }
+};
+
+export const networkOnly = async function (cacheName, event) {
+  return fetch(event.request);
+};
+
+export const raceCacheNetwork = async function (cacheName, event) {
+  let request = event.request;
+
+  let cachePromise = caches.match(request).then(
+    response => {
+      if (response) {
+        return response;
+      }
+      else
+        throw Error('cache miss');
+    }
+  );
+
+  let networkPromise = fetch(request).then(
+    response => {
+      let responseClone = response.clone();
+      caches.open(cacheName).then(cache =>
+        cache.put(request, responseClone)
+      );
+      return response;
+    }
+  );
+
+  return Promise.any([cachePromise, networkPromise]);
+};

--- a/src/serviceWorker/policies.js
+++ b/src/serviceWorker/policies.js
@@ -1,0 +1,35 @@
+import { cacheFirst, networkFirst, networkOnly } from './cachingStrategy';
+
+// the various network policies for service workers
+export const policies = [
+  {
+    // images
+    url: /^(ftp|https?):.*\.(jpe?g|png|gif|svg)($|\?.*)/i,
+    handle: cacheFirst
+  },
+  {
+    // audios & videos
+    url: /^(ftp|https?):.*\.(mp\d|webm|ogg|wav|flac)($|\?.*)/i,
+    handle: cacheFirst
+  },
+  {
+    // fonts
+    url: /^(ftp|https?):.*\.(ttf|otf|woff\d?)($|\?.*)/i,
+    handle: cacheFirst
+  },
+  {
+    // web content
+    url: /^(ftp|https?):.*\.([jt]sp?|css|html?)($|\?.*)/i,
+    handle: networkFirst
+  },
+  {
+    // web data
+    url: /^(ftp|https?):.*\.(csv|json|txt|xml)($|\?.*)/i,
+    handle: networkFirst
+  },
+  // fallback
+  {
+    url: /.+/i,
+    handle: networkOnly
+  }
+];

--- a/src/serviceWorker/policies.js
+++ b/src/serviceWorker/policies.js
@@ -12,6 +12,11 @@ export const policies = [
     handle: networkOnly
   },
   {
+    // github pages
+    url: /^https:\/\/\w*\.github\.io\/nightTab\/.*$/i,
+    handle: cacheFirst
+  },
+  {
     // images
     url: /^(ftp|https?):.*\.(jpe?g|png|gif|svg)($|\?.*)/i,
     handle: cacheFirst

--- a/src/serviceWorker/policies.js
+++ b/src/serviceWorker/policies.js
@@ -1,4 +1,4 @@
-import { cacheFirst, networkFirst, networkOnly } from './cachingStrategy';
+import { cacheFirst, networkFirst } from './cachingStrategy';
 
 // the various network policies for service workers
 export const policies = [
@@ -30,6 +30,6 @@ export const policies = [
   // fallback
   {
     url: /.+/i,
-    handle: networkOnly
-  }
+    handle: cacheFirst
+  },
 ];

--- a/src/serviceWorker/policies.js
+++ b/src/serviceWorker/policies.js
@@ -3,6 +3,11 @@ import { cacheFirst, networkFirst } from './cachingStrategy';
 // the various network policies for service workers
 export const policies = [
   {
+    // chrome extension
+    url: /^chrome-extension:.*$/i,
+    handle: networkOnly
+  },
+  {
     // images
     url: /^(ftp|https?):.*\.(jpe?g|png|gif|svg)($|\?.*)/i,
     handle: cacheFirst

--- a/src/serviceWorker/policies.js
+++ b/src/serviceWorker/policies.js
@@ -1,6 +1,10 @@
-import { cacheFirst, networkFirst } from './cachingStrategy';
+import { cacheFirst, networkFirst, networkOnly } from './cachingStrategy';
 
-// the various network policies for service workers
+/* the various network policies for service workers
+these are used to determine how to handle a request
+based on the request's url
+determine which policy to select is done based on the
+first matching pattern */
 export const policies = [
   {
     // chrome extension

--- a/src/serviceWorker/service_worker.js
+++ b/src/serviceWorker/service_worker.js
@@ -2,21 +2,34 @@ import { policies } from './policies';
 import {APP_NAME} from '../constant';
 
 self.addEventListener('install', event => { // register
-  console.log('serviceWorker installed');
+  console.log('serviceWorker installing...');
   event.waitUntil(async () => {
-    await caches.open(APP_NAME).then(
-      cache => cache.addAll([
-        '/',
-        '/index.html',
-      ])
-    );
+
+    await caches.delete(APP_NAME); // clear old cache
+    await caches.open(APP_NAME).then( cache => {
+      // check if running in chrome extension
+      if(chrome?.extension) {
+        console.log('running in chrome extension, nothing to cache');
+      }
+      else
+        cache.addAll([
+          '/',
+          '/index.html',
+        ]);
+    });
     console.log('serviceWorker installed...');
   });
 });
 
 self.addEventListener('fetch', event => { // intercept
+
+  if(event.request.method !== 'GET')
+    event.respondWith(fetch(event.request));
+
+  // only cache GET requests
   let policy = policies.find(
     pattern => pattern.url.test(event.request.url)
   );
+  console.log('fetch event ', event.request.url, ' with ', policy.handle.name);
   event.respondWith(policy.handle(APP_NAME, event));
 });

--- a/src/serviceWorker/service_worker.js
+++ b/src/serviceWorker/service_worker.js
@@ -1,12 +1,15 @@
 import { policies } from './policies';
 import {APP_NAME} from '../constant';
 
+import { version } from '../component/version';
+
+const CACHE_NAME = `${APP_NAME}-${version.number}`;
+
 self.addEventListener('install', event => { // register
   console.log('serviceWorker installing...');
   event.waitUntil(async () => {
 
-    await caches.delete(APP_NAME); // clear old cache
-    await caches.open(APP_NAME).then( cache => {
+    await caches.open(CACHE_NAME).then( cache => {
       // check if running in chrome extension
       if(chrome?.extension) {
         console.log('running in chrome extension, nothing to cache');
@@ -30,5 +33,27 @@ self.addEventListener('fetch', event => { // intercept
   let policy = policies.find(
     pattern => pattern.url.test(event.request.url)
   );
-  event.respondWith(policy.handle(APP_NAME, event));
+  event.respondWith(policy.handle(CACHE_NAME, event));
+});
+
+// Delete outdated caches
+self.addEventListener('activate', function (e) {
+  e.waitUntil(
+    caches.keys().then(function (keyList) {
+      // filter out all caches that are not part of this app
+      let cacheWhitelist = keyList.filter(function (key) {
+        return key.indexOf(APP_NAME);
+      });
+      // add current latest cache to whitelist
+      cacheWhitelist.push(CACHE_NAME);
+
+      return Promise.all(keyList.map(function (key, i) {
+        if (cacheWhitelist.indexOf(key) === -1) {
+          console.log('deleting cache : ' + keyList[i]);
+          return caches.delete(keyList[i]);
+        }
+      }));
+    })
+  );
+  console.log('serviceWorker version ' + version.number + ' activated');
 });

--- a/src/serviceWorker/service_worker.js
+++ b/src/serviceWorker/service_worker.js
@@ -1,0 +1,17 @@
+import { policies } from './policies';
+import {APP_NAME} from '../constant';
+
+self.addEventListener('install', event => { // register
+  console.log('serviceWorker installed');
+  event.waitUntil(async () => {
+    await caches.open(APP_NAME);
+    console.log('serviceWorker installed...');
+  });
+});
+
+self.addEventListener('fetch', event => { // intercept
+  let policy = policies.find(
+    pattern => pattern.url.test(event.request.url)
+  );
+  event.respondWith(policy.handle(APP_NAME, event));
+});

--- a/src/serviceWorker/service_worker.js
+++ b/src/serviceWorker/service_worker.js
@@ -13,7 +13,7 @@ self.addEventListener('install', event => { // register
       }
       else
         cache.addAll([
-          '/',
+          '/', // alias for '/index.html'
           '/index.html',
         ]);
     });

--- a/src/serviceWorker/service_worker.js
+++ b/src/serviceWorker/service_worker.js
@@ -4,7 +4,12 @@ import {APP_NAME} from '../constant';
 self.addEventListener('install', event => { // register
   console.log('serviceWorker installed');
   event.waitUntil(async () => {
-    await caches.open(APP_NAME);
+    await caches.open(APP_NAME).then(
+      cache => cache.addAll([
+        '/',
+        '/index.html',
+      ])
+    );
     console.log('serviceWorker installed...');
   });
 });

--- a/src/serviceWorker/service_worker.js
+++ b/src/serviceWorker/service_worker.js
@@ -30,6 +30,5 @@ self.addEventListener('fetch', event => { // intercept
   let policy = policies.find(
     pattern => pattern.url.test(event.request.url)
   );
-  console.log('fetch event ', event.request.url, ' with ', policy.handle.name);
   event.respondWith(policy.handle(APP_NAME, event));
 });

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,10 +4,11 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: {
-    index: path.resolve(__dirname, 'src', 'index.js')
+    index: path.resolve(__dirname, 'src', 'index.js'),
+    service_worker: path.resolve(__dirname, 'src', 'serviceWorker', 'service_worker.js'),
   },
   output: {
-    filename: '[name].[contenthash].js',
+    filename: '[name].js',
     path: path.resolve(__dirname, 'dist/web'),
     clean: true
   },
@@ -43,7 +44,8 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: './src/index.html'
+      template: './src/index.html',
+      chunks : ['index']
     }),
     new CopyPlugin({
       patterns: [{


### PR DESCRIPTION
Using this PR for service worker implementation as per  #334. As I have scrapped #339 due to it being too ugly approach.

As suggested by @metruzanca here's modular approach for creating service workers. I have added it as an entry point for webpack builds rather than direct copy of a single js file.

Registration of service workers is done at page load from `initialBackground.js` rather than by the `manifest.json`. This way it's more portable, and doesn't break as was the case when trying to use with manifest v3 in firefox. Although firefox still disallows service workers for browser extensions, the only difference will be simply service worker registration failing and proceeding as normal.

As an added benefit this also works when the page is not run as an extension. Which means for service worker unsupported browsers (in extensions only) like firefox, users can still gain the features available to service workers by simply settin the [remote url](https://zombiefox.github.io/nightTab/) as new tab page (which works even when offline).

PS: I did remove `[content-hash]` from webpack build file for js as I am not sure how to use a static name to load from `initialBackground.js`