### PR TITLE
fix: hide url when opening link to new page/tab

### DIFF
--- a/src/component/bookmarkTile/index.js
+++ b/src/component/bookmarkTile/index.js
@@ -547,6 +547,10 @@ const BookmarkTile = function({
       this.control.enable();
     } else {
       this.control.disable();
+
+      this.element.content.link.addEventListener('click', () => {
+        this.element.content.link.blur();
+      });
     }
 
   };


### PR DESCRIPTION
This PR hides the url (shown on hover) when a click occurs and opens in a new page/tab.
Without, it requires an extra click to hide the url.