### PR TITLE
fix: apply theme values to new bookmarks

### DIFF
--- a/src/component/bookmark/index.js
+++ b/src/component/bookmark/index.js
@@ -344,6 +344,9 @@ bookmark.add = {
 
     const newBookmarkData = new StagedBookmark();
 
+    newBookmarkData.link.color.opacity = state.get.current().theme.bookmark.item.opacity;
+    newBookmarkData.link.border = state.get.current().theme.bookmark.item.border;
+
     newBookmarkData.type.new = true;
 
     newBookmarkData.position.destination.item = (bookmark.all.length > 0) ? bookmark.all[0].items.length : 0;


### PR DESCRIPTION
## Summary
**New bookmarks weren't inheriting theme properties** like border size and opacity. Instead, they used default values (bookmarkDefault)

## Demonstration
I've changed the opacity and border size in the theme and added new bookmarks. Those bookmarks don't have the same theme as the others do. Refreshing does not help here. Only when changing the theme's settings, the new bookmark is updated.

https://github.com/user-attachments/assets/3f2af5f9-3eaf-420a-a720-f6c60a7ddb93

## Changes
`src/component/bookmark/index.js`
After creating a bookmark, the theme gets applied to match the appearance of existing bookmarks.

Currently, this includes:
- Opacity
- Border size